### PR TITLE
Use GitPython to handle git operations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "sqlalchemy",
         "sqlalchemy-utils",
         "h5py",
+        "GitPython",
     ],
     extras_require={"test": ["pytest"], "dataverse": ["easyDataverse"]},
 )


### PR DESCRIPTION
The previous implementation used ```subprocess``` to call Git, which felt a bit sketchy. With this implementation ```GitPython``` is used instead, because it is easier to implement, tested and faster.