### PR TITLE
20 lowest level elements in xml cannot have attributes and content

### DIFF
--- a/sdRDM/base/ioutils/xml.py
+++ b/sdRDM/base/ioutils/xml.py
@@ -9,62 +9,62 @@ from sdRDM.base.listplus import ListPlus
 # ! Reader
 def read_xml(xml_string: bytes, object: "DataModel") -> Dict:
     """Parses a given XML file or StringIO to a a dictionary
-    
+
     This function closely operates with the given data model
     and inferes types and general structural information from
     the model.
     """
-    
+
     root = etree.fromstring(xml_string)
     library = gather_object_types(object)
-    
+
     return parse_xml_element_to_model(library, root)
 
+
 def gather_object_types(obj) -> Dict:
-    """Gets all sub types found in a """
-    
+    """Gets all sub types found in a"""
+
     objects = {obj.__name__: obj}
-    
+
     for field in obj.__fields__.values():
         if hasattr(field.type_, "__fields__"):
             subobject = field.type_
-            objects[subobject.__name__] =subobject
-            objects.update({
-                **gather_object_types(subobject),
-                subobject.__name__: subobject
-            })
-            
+            objects[subobject.__name__] = subobject
+            objects.update(
+                {**gather_object_types(subobject), subobject.__name__: subobject}
+            )
+
     return objects
 
-def parse_xml_element_to_model(library: Dict, element: _Element) -> Dict:
 
+def parse_xml_element_to_model(library: Dict, element: _Element) -> Dict:
     cls = library[element.tag]
     attributes, alias_map, objects = prepare_xml_parsing(cls)
-    
+
     for subelement in element:
         # Go through each element and add it to the attributes
         map_xml_element(attributes, subelement, alias_map, library, objects)
-        
+
     for name, value in element.attrib.items():
-        attributes[name] = value        
-            
+        attributes[name] = value
+
     return attributes
+
 
 def prepare_xml_parsing(object: "DataModel") -> Tuple[Dict, Dict, List[str]]:
     """Retrieves attributes and preparse parsing of an XML object"""
-    
+
     attributes = {}
     alias_map = {}
     objects = []
 
     # Prepare for expected attributes
     for name, attr in object.__fields__.items():
-        
         is_multiple = get_origin(attr.outer_type_) == list
         is_object = hasattr(attr.type_, "__fields__")
-        
+
         alias_map[name] = name
-        
+
         if is_object and is_multiple:
             attributes[name] = []
             objects.append(name)
@@ -76,40 +76,39 @@ def prepare_xml_parsing(object: "DataModel") -> Tuple[Dict, Dict, List[str]]:
             attributes[name] = []
         else:
             attributes[name] = None
-    
+
         if "xml" in attr.field_info.extra:
             # Overrides all other things
             alias_map[attr.field_info.extra["xml"].replace("@", "")] = name
-            
+
     return attributes, alias_map, objects
+
 
 def map_xml_element(
     attributes: Dict,
     element: _Element,
     alias_map: Dict,
     library: Dict,
-    objects: List[str]
+    objects: List[str],
 ) -> None:
     """Parses a sub element found in an XML document and maps it accordingly to the data model"""
-    
+
     attr_name = alias_map[element.tag]
     is_multiple = isinstance(attributes[attr_name], list)
     is_object = attr_name in objects
-    
+
     if is_object and not is_multiple:
-        attributes[attr_name] = parse_xml_element_to_model(
-            library, element
-        )
+        attributes[attr_name] = parse_xml_element_to_model(library, element)
     elif is_object and is_multiple:
         attributes[attr_name] += [
-            parse_xml_element_to_model(library, subelement)
-            for subelement in element
+            parse_xml_element_to_model(library, subelement) for subelement in element
         ]
     elif not is_object and is_multiple:
         attributes[attr_name] += [element.text]
     else:
         attributes[attr_name] = element.text
-    
+
+
 # ! Writer
 def write_xml(obj, pascal: bool = True):
     node = etree.Element(
@@ -124,6 +123,13 @@ def write_xml(obj, pascal: bool = True):
 
         if value is None:
             # Skip None values
+            continue
+
+        if name.lower() == obj.__class__.__name__.lower():
+            node.text = str(value)
+            continue
+        elif xml_option == obj.__class__.__name__:
+            node.text = str(value)
             continue
 
         if not xml_option:


### PR DESCRIPTION
**Overview**

For more context see issue #20 

**Features**

* Extends XML serializer with a check to assign the same named attribute/XML-option as an elements value
* Allows attributes on a terminal element

**ToDos**

- [ ] Validate terminal element (no sub models)

**Example**

Used models can be found [here](https://www.dropbox.com/scl/fo/iwa4urmct9x5b7m5sqgnp/h?dl=0&rlkey=try56wh8ou3kdm5tdxuq51wom)

_Case 1 - Attribute has same name as class_

```python
# Case 1: Name of attr is same as lowercase object 
lib = DataModel.from_markdown("./model1.md")

dataset = lib.Parent(an_attribute="lelel", another_attribute=1)
dataset.xml_element_without_content = dataset.__types__.xml_element_without_content(
    element="Hello!", an_attribute="lelel", another_attribute=1
)

print(dataset.xml())
```

```XML
<?xml version='1.0' encoding='UTF-8'?>
<Parent id="parent0">
  <Element id="element0" anAttribute="lelel" anotherAttribute="1">Hello!</Element>
</Parent>
```

_Case 2 - XML option has the same name as class_

```python
lib = DataModel.from_markdown("./model2.md")

dataset = lib.Parent(an_attribute="lelel", another_attribute=1)
dataset.xml_element_without_content = dataset.__types__.xml_element_without_content(
    different="Hello!", an_attribute="lelel", another_attribute=1
)

print(dataset.xml())
```

```XML
<?xml version='1.0' encoding='UTF-8'?>
<Parent id="parent0">
  <Element id="element0" anAttribute="lelel" anotherAttribute="1">Hello!</Element>
</Parent>
```