### PR TITLE
22 error pydantic email validator is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "autoflake==2.0.0",
         "graphql-core==3.2.3",
         "bigtree",
+        "email-validator",
     ],
     extras_require={"test": ["pytest"], "dataverse": ["easyDataverse"]},
 )


### PR DESCRIPTION
**Overview**

The sdRDM library offers a data type to validate mails, which is kindly supplied by PyDantic. Yet this type depends on another library called `email-validator` to be used (as mentioned in issue #22). This PR extends the list of dependencies to `email-validator` to fix this.

**Issues that this PR fixes**

Fixes #22 