### PR TITLE
Add nested git generation

### DIFF
--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -25,6 +25,7 @@ from h5py._hl.files import File as H5File
 from h5py._hl.dataset import Dataset as H5Dataset
 from lxml import etree
 from pydantic import PrivateAttr, validator
+from pydantic.main import ModelMetaclass
 from sqlalchemy.orm import declarative_base
 from typing import List, Dict, Optional, IO, Union, get_args, Callable
 from astropy.units import Unit
@@ -52,7 +53,13 @@ from sdRDM.tools.gitutils import (
 )
 
 
-class DataModel(pydantic.BaseModel):
+class Meta(ModelMetaclass):
+    def __str__(cls):
+        cls.meta_tree()
+        return ""
+
+
+class DataModel(pydantic.BaseModel, metaclass=Meta):
     class Config:
         validate_assignment = True
         use_enum_values = True

--- a/sdRDM/linking/link.py
+++ b/sdRDM/linking/link.py
@@ -75,34 +75,35 @@ def _build_source(source: str) -> "DataModel":
 def _get_git_source(source: str, data_model: "DataModel") -> "DataModel":
     """Fetches a git source from the given string."""
 
-    if _has_commit(source):
-        tag = None
-        commit = re.split(r"@", source)[1]
-        url = re.split(r"@", source)[0]
-    elif _has_tag(source):
-        commit = None
-        tag = re.split(r"#", source)[1]
-        url = re.split(r"#", source)[0]
+    if _has_tag_or_commit(source):
+        commit = re.split(r"@", source)[1].strip()
+        url = re.split(r"@", source)[0].strip()
+
+        return data_model.from_git(url=url, commit=commit)
     else:
-        commit = None
-        tag = None
-        url = source
-
-    return data_model.from_git(
-        url=url,
-        tag=tag,
-        commit=commit,
-    )
+        return data_model.from_git(url=source)
 
 
-def _has_tag(source: str) -> bool:
+def _has_tag_or_commit(source: str) -> bool:
     """Checks whether the given source has a tag."""
-    return bool(re.match(r".*#.*", source))
+
+    if "@" not in source:
+        return False
+
+    return True
 
 
 def _has_commit(source: str) -> bool:
     """Checks whether the given source has a commit."""
-    return bool(re.match(r".*@.*", source))
+
+    if "@" not in source:
+        return False
+
+    tag = re.split(r"@", source)[1].strip()
+
+    print("CHECK", validators.sha256(tag))
+
+    return validators.sha256(tag)  # type: ignore
 
 
 def _assemble_dataset(


### PR DESCRIPTION
This PR introduces the functionality to add remote models within a given one. This is done by applying the following schema to an attributes `Type`:

```
https://www.github.com/user/mymodel.git@ObjectOfInterest
```

It will add the corresponding object of interest to the generation process of the initial one. We might think about making this more specific by allowing specification of branches/tags/commits to make sure it's actually the intended version of the nested model. Something along that line:

```
ObjectOfInterest@https://www.github.com/user/mymodel.git#somecommit
```

@haeussma what are your thoughts?


**Additional docs**

* This PR also fixes `date` interfering with attributes named the same way by simply import `date` as `Date`.