### PR TITLE
Update code base to PyDantic v2

### DIFF
--- a/sdRDM/__init__.py
+++ b/sdRDM/__init__.py
@@ -1,2 +1,2 @@
 from .base.datamodel import DataModel
-from pydantic import Field, validator
+from pydantic import Field, field_validator

--- a/sdRDM/base/ioutils/hdf5.py
+++ b/sdRDM/base/ioutils/hdf5.py
@@ -44,7 +44,6 @@ def write_hdf5(dataset, file: Union[H5File, str]):
 
 
 def read_hdf5(obj, file):
-
     tree, _ = obj.create_tree()
     meta_paths = obj.meta_paths(leaves=True)
 
@@ -86,10 +85,10 @@ def _write_source(dataset, file: H5File):
 
     try:
         # Add Git info if given
-        if dataset.__repo__:
-            group.attrs["repo"] = (dataset.__repo__,)  # type: ignore
-        group.attrs["commit"] = (dataset.__commit__,)  # type: ignore
-        group.attrs["url"] = (dataset.__repo__.replace(".git", f"/tree/{dataset.__commit__}"),)  # type: ignore
+        if dataset._repo:
+            group.attrs["repo"] = (dataset._repo,)  # type: ignore
+        group.attrs["commit"] = (dataset._commit,)  # type: ignore
+        group.attrs["url"] = (dataset._repo.replace(".git", f"/tree/{dataset._commit}"),)  # type: ignore
     except AttributeError:
         pass
 

--- a/sdRDM/base/listplus.py
+++ b/sdRDM/base/listplus.py
@@ -8,15 +8,15 @@ class ListPlus(List[Any]):
     attributes.
     """
 
-    __parent__: "DataModel"
-    __types__: List["DataModel"]
-    __attribute__: str
+    _parent: "DataModel"
+    _types: List["DataModel"]
+    _attribute: str
 
     def __init__(self, *args, **kwargs):
         super(ListPlus, self).__init__()
 
-        self.__parent__ = None
-        self.__attribute__ = None
+        self._parent = None
+        self._attribute = None
 
         for arg in args:
             if "generator object" in repr(arg):
@@ -28,17 +28,17 @@ class ListPlus(List[Any]):
     def append(self, *args):
         for arg in args:
             if hasattr(arg, "__fields__") and self.is_part_of_model():
-                arg.__parent__ = self.__parent__
-                arg.check_references(self.__attribute__, arg)
+                arg._parent = self._parent
+                arg.check_references(self._attribute, arg)
 
             super().append(arg)
 
     def is_part_of_model(self) -> bool:
         """Checks whether this list is already integrated"""
-        return self.__parent__ is not None and self.__attribute__ is not None
+        return self._parent is not None and self._attribute is not None
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name == "__parent__" and value is not None:
+        if name == "_parent" and value is not None:
             self.set_parent_for_object_entries(value)
 
         return super().__setattr__(name, value)
@@ -49,7 +49,7 @@ class ListPlus(List[Any]):
             if not hasattr(entry, "__fields__"):
                 continue
 
-            entry.__parent__ = parent
+            entry._parent = parent
 
     def get(self, query: Callable, attr: str = "id"):
         """Given an a query, returns all objects that match

--- a/sdRDM/base/referencecheck.py
+++ b/sdRDM/base/referencecheck.py
@@ -1,4 +1,3 @@
-from pydantic.fields import ModelField
 from typing import Tuple, Dict, Optional
 
 
@@ -60,10 +59,10 @@ def traverse_to_root_node(obj: "DataModel", root: str) -> Optional["DataModel"]:
     while True:
         if obj.__class__.__name__ == root:
             return obj
-        elif obj.__parent__ is None:
+        elif obj._parent is None:
             return None
 
-        obj = obj.__parent__
+        obj = obj._parent
 
 
 def get_fields_to_check(obj: "DataModel") -> Dict:
@@ -80,12 +79,12 @@ def get_fields_to_check(obj: "DataModel") -> Dict:
     return checks
 
 
-def has_reference_check(field: ModelField) -> bool:
+def has_reference_check(field) -> bool:
     """Checks whether a field has a reference info"""
     return "references" in field.field_info.extra
 
 
-def get_field_reference_check(field: ModelField) -> Tuple[str, str]:
+def get_field_reference_check(field) -> Tuple[str, str]:
     """Extracts root and path from a refrence field"""
     root, *path = field.field_info.extra["references"].split(".")
     return (root, "/".join(path))

--- a/sdRDM/generator/templates/class_template.jinja2
+++ b/sdRDM/generator/templates/class_template.jinja2
@@ -16,5 +16,5 @@ class {{name}}({% if inherit is not none %}
     {{ attribute }}
     {% endfor -%}
     
-    {% if repo is not none %}__repo__: Optional[str] = PrivateAttr(default="{{repo}}"){% endif %}
-    {% if commit is not none %}__commit__: Optional[str] = PrivateAttr(default="{{commit}}"){% endif %}
+    {% if repo is not none %}_repo: Optional[str] = PrivateAttr(default="{{repo}}"){% endif %}
+    {% if commit is not none %}_commit: Optional[str] = PrivateAttr(default="{{commit}}"){% endif %}

--- a/sdRDM/generator/templates/reference_template.jinja2
+++ b/sdRDM/generator/templates/reference_template.jinja2
@@ -1,4 +1,5 @@
-    @validator("{{attribute}}")
+    @field_validator("{{attribute}}")
+    @classmethod
     def get_{{attribute}}_reference(cls, value):
         """Extracts the ID from a given object to create a reference"""
 

--- a/sdRDM/linking/utils.py
+++ b/sdRDM/linking/utils.py
@@ -1,8 +1,8 @@
 import yaml
 import toml
+import inspect
 
 from anytree import LevelOrderIter
-from pydantic.main import ModelMetaclass
 from typing import get_origin
 
 from sdRDM.linking.nodes import AttributeNode, ClassNode, ListNode
@@ -19,7 +19,7 @@ def build_guide_tree(obj: "DataModel") -> ClassNode:
         ClassNode: Tree of AttributeNodes and ClassNodes representing the data model
     """
 
-    if isinstance(obj, ModelMetaclass):
+    if inspect.isclass(obj):
         return _build_class_tree(obj)
 
     return _build_instance_tree(obj)


### PR DESCRIPTION
PyDantic recently has updated to version `2.0.1` with many changes. This breaks parts of the `sdRDM` library and prevents basic functionality (#34). Hence, this draft adds changes to comply with the new features.

- [x] Update private fields
- [x] Update validators
- [ ] Remove `__fields__` calls