### PR TITLE
Object references

### DIFF
--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -60,9 +60,11 @@ class DataModel(pydantic.BaseModel):
     __node__: Optional[Node] = PrivateAttr(default=None)
     __types__: DottedDict = PrivateAttr(default=dict)
     __parent__: Optional["DataModel"] = PrivateAttr(default=None)
+    __references__: DottedDict = PrivateAttr(default_factory=DottedDict)
 
     def __init__(self, **data):
         super().__init__(**data)
+        self._initialize_references()
 
         for field, value in self.__dict__.items():
             if not isinstance(value, ListPlus):
@@ -81,6 +83,11 @@ class DataModel(pydantic.BaseModel):
                 self.__types__[name] = tuple(
                     [subtype for subtype in args if hasattr(subtype, "__fields__")]
                 )
+
+    def _initialize_references(self):
+        """Initialized references for each field present in the data model"""
+        for field in self.__fields__:
+            self.__references__[field] = ListPlus()
 
     # ! Getters
     def get(
@@ -207,7 +214,7 @@ class DataModel(pydantic.BaseModel):
         """Returns all possible paths of an instantiated data model. Can also be reduced to just leaves."""
 
         metapaths = set()
-        for node in LevelOrderIter(cls.create_tree()[0]):
+        for node in LevelOrderIter(cls.meta_tree(show=False)):
             if len(node.node_path) == 1:
                 continue
 
@@ -745,18 +752,36 @@ class DataModel(pydantic.BaseModel):
 
     # ! Overloads
     def __setattr__(self, name, value):
-        if name == "__parent__" or name == "__types__":
+        if bool(re.match("__[a-zA-Z0-9]*__", name)):
             return super().__setattr__(name, value)
 
-        self.set_parent_instances(value)
-        self.check_references(name, value)
+        self._add_reference_to_object(name, value)
+        self._set_parent_instances(value)
+        self._check_references(name, value)
 
         super().__setattr__(name, value)
 
         if isinstance(value, list):
             self.__dict__[name].__parent__ = self
 
-    def check_references(self, name, value):
+    def _add_reference_to_object(self, name, value):
+        """Adds the current class to the referenced object to maintain its relation"""
+
+        extra = self.__fields__[name].field_info.extra
+
+        if "reference" not in extra:
+            return
+        elif not hasattr(value, "__fields__"):
+            return
+
+        # Add the relation to the attribute of this field
+        self.__references__[name].append(value)
+
+        # Also add it to the other object
+        target_attr = extra["reference"].split(".")[-1]
+        value.__references__[target_attr].append(self)
+
+    def _check_references(self, name, value):
         """Checks whether references are compliant"""
 
         if self.is_data_model(value):
@@ -775,7 +800,7 @@ class DataModel(pydantic.BaseModel):
                 """
             )
 
-    def set_parent_instances(self, value) -> None:
+    def _set_parent_instances(self, value) -> None:
         """Sets current instance as the parent to objects"""
         if isinstance(value, ListPlus):
             value.__parent__ = self

--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -15,6 +15,7 @@ import warnings
 import numpy as np
 
 from nob import Nob
+from nob.path import Path
 from dotted_dict import DottedDict
 from enum import Enum
 from anytree import Node, LevelOrderIter
@@ -96,6 +97,9 @@ class DataModel(pydantic.BaseModel):
         attribute: Optional[str] = None,
         target: Union[str, float, int, None, "DataModel", Callable] = None,
     ):
+        if isinstance(path, Path):
+            path = str(path)
+        
         if not path.startswith("/") and len(path.split("/")) > 1:
             path = f"/{path}"
 

--- a/sdRDM/base/ioutils/hdf5.py
+++ b/sdRDM/base/ioutils/hdf5.py
@@ -1,8 +1,8 @@
 import os
 import numpy as np
+import datetime
 
 from anytree import findall
-from datetime import date, datetime
 from numpy.typing import NDArray
 from typing import Union
 
@@ -30,9 +30,13 @@ def write_hdf5(dataset, file: Union[H5File, str]):
         prefix, attribute = path.split()
         prefix = str(prefix)
 
-        if str(prefix) == "/":
+        if isinstance(data, list) and len(data) == 1:
+            data = data[0]
+
+        if prefix == "/":
             # Write root attributes directly
-            _write_attr(prefix, dataset.get(path), file)
+            _write_attr(attribute, data, file)
+            continue
 
         # Fetch or create a group
         group = _get_group(file, prefix)
@@ -44,7 +48,6 @@ def write_hdf5(dataset, file: Union[H5File, str]):
 
 
 def read_hdf5(obj, file):
-
     tree, _ = obj.create_tree()
     meta_paths = obj.meta_paths(leaves=True)
 
@@ -97,7 +100,7 @@ def _write_source(dataset, file: H5File):
 def _write_attr(name, value, h5obj: Union[H5File, H5Group]):
     """Writes an attribute to an HDF5 root or group"""
 
-    if isinstance(value, (date, datetime)):
+    if isinstance(value, (datetime.date, datetime.datetime)):
         # HDF5 does not like date types
         value = str(value)
 

--- a/sdRDM/base/listplus.py
+++ b/sdRDM/base/listplus.py
@@ -29,7 +29,7 @@ class ListPlus(List[Any]):
         for arg in args:
             if hasattr(arg, "__fields__") and self.is_part_of_model():
                 arg.__parent__ = self.__parent__
-                arg.check_references(self.__attribute__, arg)
+                arg._check_references(self.__attribute__, arg)
 
             super().append(arg)
 


### PR DESCRIPTION
**Overview**

Complex types, such as objects that are assigned to an attribute, are now referenced on both sides. For instance, if a `Species` object has been added to a `Reaction,` where both live in different branches of the tree, one can still see where each has been referenced and use the object.

```python
species = dataset.add_to_species(...)
reaction = dataset.add_to_reactions(id="r1", ...)
reaction.species_id = species

species.__references__  # This will include the reference to the reaction
reaction.__references__  # This will include the reference to the species
```