### PR TITLE
Added small types to reduce model size

### DIFF
--- a/sdRDM/generator/classrender.py
+++ b/sdRDM/generator/classrender.py
@@ -261,7 +261,6 @@ def get_complex_types(attribute: Dict, objects: List[Dict]) -> List[str]:
     """Checks whether an attributes types contain multiple complex types"""
 
     complex_types = []
-    print(attribute)
 
     for type in attribute["type"]:
         if is_enum_type(type, objects):
@@ -359,8 +358,6 @@ def assemble_signature(
     small_types: Dict,
 ) -> List[Dict]:
     """Takes a non-native sdRDM type defined within the model and extracts all attributes"""
-
-    print("LELEL", type, obj_name)
 
     try:
         sub_object = next(filter(lambda object: object["name"] == type, objects))

--- a/sdRDM/generator/classrender.py
+++ b/sdRDM/generator/classrender.py
@@ -21,17 +21,61 @@ def render_object(
 
     all_objects = objects + enums
 
+    # Keep track of small types
+    small_types = {small_type["name"]: small_type for small_type in object["subtypes"]}
+
+    if small_types:
+        small_type_part = "\n".join(
+            [
+                render_class(
+                    object=subtype,
+                    inherits=[],
+                    objects=all_objects,
+                    repo=repo,
+                    commit=commit,
+                )
+                for subtype in object["subtypes"]
+            ]
+        )
+    else:
+        small_type_part = ""
+
     # Get the class body
     class_part = render_class(
-        object=object, inherits=inherits, objects=all_objects, repo=repo, commit=commit
+        object=object,
+        inherits=inherits,
+        objects=all_objects,
+        repo=repo,
+        commit=commit,
     )
-    methods_part = render_add_methods(object=object, objects=all_objects)
-    validator_part = render_reference_validator(object=object, objects=all_objects)
-    class_body = "\n".join([class_part, methods_part, validator_part])
+
+    methods_part = render_add_methods(
+        object=object,
+        objects=all_objects,
+        small_types=small_types,
+    )
+
+    validator_part = render_reference_validator(
+        object=object,
+        objects=all_objects,
+    )
+
+    class_body = "\n".join(
+        [
+            small_type_part,
+            class_part,
+            methods_part,
+            validator_part,
+        ]
+    )
 
     # Clean and render imports
     imports = render_imports(
-        object=object, objects=all_objects, inherits=inherits, obj_name=object["name"]
+        object=object,
+        objects=all_objects,
+        inherits=inherits,
+        obj_name=object["name"],
+        small_types=small_types,
     )
 
     return f"{imports}\n\n{class_body}"
@@ -53,7 +97,6 @@ def render_class(
 
     inherit = None
     name = object.pop("name")
-
     filtered = list(filter(lambda element: element["child"] == name, inherits))
 
     if filtered and len(filtered) == 1:
@@ -64,7 +107,12 @@ def render_class(
         inherit=inherit,
         docstring=object.pop("docstring"),
         attributes=[
-            render_attribute(attr, objects, name) for attr in object["attributes"]
+            render_attribute(
+                attr,
+                objects,
+                name,
+            )
+            for attr in object["attributes"]
         ],
         repo=repo,
         commit=commit,
@@ -185,7 +233,7 @@ def is_reference(key: str, option: str) -> bool:
     return False
 
 
-def render_add_methods(object: Dict, objects: List[Dict]) -> str:
+def render_add_methods(object: Dict, objects: List[Dict], small_types: Dict) -> str:
     """Renders add methods fro each non-native type of an attribute"""
 
     add_methods = []
@@ -197,7 +245,12 @@ def render_add_methods(object: Dict, objects: List[Dict]) -> str:
         for type in complex_types:
             add_methods.append(
                 render_single_add_method(
-                    attribute, type, objects, is_single_type, object["name"]
+                    attribute,
+                    type,
+                    objects,
+                    is_single_type,
+                    object["name"],
+                    small_types,
                 )
             )
 
@@ -208,6 +261,7 @@ def get_complex_types(attribute: Dict, objects: List[Dict]) -> List[str]:
     """Checks whether an attributes types contain multiple complex types"""
 
     complex_types = []
+    print(attribute)
 
     for type in attribute["type"]:
         if is_enum_type(type, objects):
@@ -264,7 +318,12 @@ def is_enum_type(name: str, objects: List[Dict]) -> bool:
 
 
 def render_single_add_method(
-    attribute: Dict, type: str, objects: List[Dict], is_single_type: bool, obj_name: str
+    attribute: Dict,
+    type: str,
+    objects: List[Dict],
+    is_single_type: bool,
+    obj_name: str,
+    small_types: Dict,
 ) -> str:
     """Renders an add method for an attribute that occurs multiple times"""
 
@@ -288,28 +347,41 @@ def render_single_add_method(
         attribute=attribute["name"],
         destination=destination,
         cls=type,
-        signature=assemble_signature(type, objects, obj_name),
+        signature=assemble_signature(type, objects, obj_name, small_types),
         summary=f"This method adds an object of type '{type}' to attribute {attribute['name']}",
     )
 
 
-def assemble_signature(type: str, objects: List[Dict], obj_name: str) -> List[Dict]:
+def assemble_signature(
+    type: str,
+    objects: List[Dict],
+    obj_name: str,
+    small_types: Dict,
+) -> List[Dict]:
     """Takes a non-native sdRDM type defined within the model and extracts all attributes"""
+
+    print("LELEL", type, obj_name)
 
     try:
         sub_object = next(filter(lambda object: object["name"] == type, objects))
-        sub_object_attrs = sub_object["attributes"]
-        sub_object_parent = sub_object.get("parent")
-
     except StopIteration:
-        raise ValueError(f"Sub object '{type}' has no attributes.")
+        if type in small_types:
+            sub_object = small_types[type]
+        else:
+            raise ValueError(f"Sub object '{type}' has no attributes.")
 
+    sub_object_parent = sub_object.get("parent")
     sub_object_attrs = [
-        convert_type(attribute, obj_name) for attribute in sub_object_attrs
+        convert_type(attribute, obj_name) for attribute in sub_object["attributes"]
     ]
 
-    if sub_object_parent:
-        sub_object_attrs += assemble_signature(sub_object_parent, objects, obj_name)
+    if sub_object_parent is not None:
+        sub_object_attrs += assemble_signature(
+            sub_object_parent,
+            objects,
+            obj_name,
+            small_types,
+        )
 
     return sorted(sub_object_attrs, key=sort_by_defaults, reverse=True)
 
@@ -375,14 +447,20 @@ def encapsulate_type(dtypes: List[str], is_multiple: bool, is_required: bool) ->
 
 
 def render_imports(
-    object: Dict, objects: List[Dict], inherits: List[Dict], obj_name: str
+    object: Dict,
+    objects: List[Dict],
+    inherits: List[Dict],
+    obj_name: str,
+    small_types: Dict,
 ) -> str:
     """Retrieves all necessary external and local imports for this class"""
 
     objects = deepcopy(objects)
     object = deepcopy(object)
 
-    all_types = gather_all_types(object["attributes"], objects, object["name"])
+    all_types = gather_all_types(
+        object["attributes"], objects, small_types, object["name"]
+    )
 
     for inherit in inherits:
         if inherit["child"] != object["name"]:
@@ -390,7 +468,9 @@ def render_imports(
 
         parent_type = inherit["parent"]
         all_types += gather_all_types(
-            get_object(parent_type, objects)["attributes"], objects
+            get_object(parent_type, objects)["attributes"],
+            objects,
+            small_types,
         ) + [parent_type]
 
     # Sort types into local and from imports
@@ -404,7 +484,9 @@ def render_imports(
     local_imports = [
         f"from .{type.lower()} import {type}"
         for type in all_types
-        if type not in DataTypes.__members__ and type != obj_name
+        if type not in DataTypes.__members__
+        and type != obj_name
+        and type not in small_types
     ]
 
     imports = [
@@ -425,7 +507,10 @@ def render_imports(
 
 
 def gather_all_types(
-    attributes: List[Dict], objects: List[Dict], obj_name: str = ""
+    attributes: List[Dict],
+    objects: List[Dict],
+    small_types: Dict,
+    obj_name: str = "",
 ) -> List[str]:
     """Gets the occuring types in all attributes"""
 
@@ -438,7 +523,7 @@ def gather_all_types(
             if nested_type == obj_name:
                 continue
 
-            types += process_subtypes(nested_type, objects)
+            types += process_subtypes(nested_type, objects, small_types)
 
     return types
 
@@ -452,12 +537,18 @@ def get_object(name: str, objects: List[Dict]) -> Dict:
         raise ValueError(f"Could not find object '{name}' in objects.")
 
 
-def process_subtypes(nested_type: str, objects: List[Dict]) -> List[str]:
+def process_subtypes(
+    nested_type: str,
+    objects: List[Dict],
+    small_types: Dict,
+) -> List[str]:
     """Processes types from nested attribute types"""
 
     types = []
 
     if nested_type in DataTypes.__members__:
+        return []
+    elif nested_type in small_types:
         return []
 
     object = get_object(nested_type, objects)
@@ -466,12 +557,12 @@ def process_subtypes(nested_type: str, objects: List[Dict]) -> List[str]:
         return []
 
     attributes = object["attributes"]
-    subtypes = gather_all_types(attributes, objects, object["name"])
+    subtypes = gather_all_types(attributes, objects, small_types, object["name"])
 
     if object.get("parent"):
         parent_obj = get_object(object["parent"], objects)
         subtypes += gather_all_types(
-            parent_obj["attributes"], objects, parent_obj["name"]
+            parent_obj["attributes"], objects, small_types, parent_obj["name"]
         )
 
     for subtype in subtypes:

--- a/sdRDM/markdown/objectutils.py
+++ b/sdRDM/markdown/objectutils.py
@@ -2,7 +2,9 @@ import re
 
 from markdown_it.token import Token
 from typing import List, Dict, Tuple
+from sdRDM.markdown.smalltypes import process_small_type
 
+from sdRDM.tools.utils import snake_to_camel
 from sdRDM.markdown.tokens import MarkdownTokens
 
 OPTION_PATTERN = r"\s*([A-Za-z0-9\_]*)\s*\:\s*(.*)"
@@ -72,6 +74,7 @@ def process_object(element: Token, object_stack: List, **kwargs) -> None:
             "docstring": "",
             "attributes": [],
             "type": "object",
+            "subtypes": [],
         }
     )
 
@@ -170,8 +173,19 @@ def process_type_option(
 
     processed_types = []
 
+    if has_small_type(dtypes):
+        small_type = process_small_type(dtypes, object_stack)
+        object_stack[-1]["subtypes"].append(small_type)
+
+        # Update dtypes and add the small type to the processed types
+        dtypes = re.sub(r"\{.*\}", "", dtypes).strip(",")
+        processed_types.append(small_type["name"])
+
     for dtype in dtypes.split(","):
         dtype = dtype.strip()
+
+        if not dtype:
+            continue
 
         if is_remote_type(dtype):
             dtype, cls_defs, url = process_remote_type(dtype)
@@ -195,8 +209,13 @@ def process_type_option(
 
 def is_remote_type(dtype: str) -> bool:
     """Checks whether the given type points to a remote model"""
-    # TODO find a safer way
     return "@" in dtype and "github" in dtype
+
+
+def has_small_type(dtype: str) -> bool:
+    # Pattern is {name: type, name: type, ...}
+    pattern = r"\{.*\}"
+    return bool(re.match(pattern, dtype))
 
 
 def is_linked_type(dtype: str) -> bool:

--- a/sdRDM/markdown/smalltypes.py
+++ b/sdRDM/markdown/smalltypes.py
@@ -1,0 +1,77 @@
+import re
+from typing import Dict, List
+from sdRDM.generator.datatypes import DataTypes
+from sdRDM.tools.utils import snake_to_camel
+
+
+def process_small_type(dtypes: str, object_stack: List[Dict]):
+    """Processes small types of form {name: type, ...} to a valid object
+
+    So called small types can be added to the sdRDM markdown syntax
+    by using the following syntax:
+
+        - attribute
+            - name: {name: type, name: type, ...}
+
+    This way no extra object (l3 heading) has to be defined for a small
+    type that will most likely stay this way.
+
+    """
+
+    small_type = re.match(r"\{(.*)\}", dtypes).groups()[0]
+    attr_name = object_stack[-1]["attributes"][-1]["name"]
+
+    small_type_name = snake_to_camel(
+        object_stack[-1]["attributes"][-1]["name"]
+    ).capitalize()
+
+    return {
+        "name": small_type_name,
+        "attr_name": attr_name,
+        "attributes": _extract_attributes(small_type, attr_name),
+        "docstring": f"Small type for attribute '{attr_name}'",
+        "type": "object",
+        "parent": None,
+    }
+
+
+def _extract_attributes(dtypes: str, attr_name: str) -> List[Dict]:
+    """Extracts all attributes from a small type"""
+
+    attributes = []
+    for attribute in dtypes.split(","):
+        if ":" not in attribute:
+            raise ValueError(
+                f"Small type: Attribute '{attribute}' for '{attr_name}' is not valid."
+            )
+
+        name, dtype = attribute.split(":")
+
+        # Perform checks on the attribute
+        _validate_attribute(attribute, attr_name, name, dtype)
+
+        attributes.append(
+            {
+                "name": name.strip(),
+                "type": [attribute.split(":")[1].strip()],
+                "required": False,
+            }
+        )
+
+    return attributes
+
+
+def _validate_attribute(attribute, attr_name, name, dtype):
+    """Basics checks for an attribute"""
+
+    assert (
+        name.strip()
+    ), f"Small type: Sub-attribute '{attribute}' for attribute '{attr_name}' has no name."
+    assert (
+        dtype.strip()
+    ), f"Small type: Sub-attribute '{attribute}' for attribute '{attr_name}' has no type."
+
+    if dtype.strip() not in DataTypes.__members__:
+        raise ValueError(
+            f"Small type: Type '{dtype}' is not valid. Please, only use base datatypes for small types"
+        )


### PR DESCRIPTION
### Overview

This pull request is introducing a new syntax called `Type` to make it easier to create `small types` on the spot. This change is necessary for creating a `ThermoML` markdown, as nested types are often needed and require their own level 3 headings.

**Format example**

```xml
<Component>
      <RegNum>
            <nOrgNum>3</nOrgNum>
      </RegNum>
      <nSampleNm>1</nSampleNm>
</Component>
```

**Corresponding markdown**

> ### Component
> 
> - RegNum
>   - Type: RegNum
> ### RegNum
> 
> - nOrgNum
>   - Type: string   

In the given case, an extra object `RegNum` has to be defined to represent the data structure. This addition increases the height of the markdown document and introduces a new layer of complexity. Furthermore, this distorts the general idea of the parent object since it implies, that there seems to be a deeper concept, although the additional object merely holds a single value.

To solve this, small types can be introduced at the attribute level, which will help the document height. These are limited to base types (`float`, `string`, etc.) to prevent unnecessary complexity. In order to solve the above problem, the introduction of a `small type` replaces the additional object.

**Small type markdown**

> ### Component
> 
> - RegNum
>   - Type: {nOrgNum:  string}

There is no alteration or addition of default behavior with this approach. The resulting class works like any other and can be linked as usual. However, it's important to note that the resulting name of the class will match the attributes capitalized camel-cased name. 