### PR TITLE
Added internal ID

### DIFF
--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shutil
+import uuid
 import h5py
 import pydantic
 import random
@@ -63,6 +64,7 @@ class DataModel(pydantic.BaseModel):
     __types__: DottedDict = PrivateAttr(default=dict)
     __parent__: Optional["DataModel"] = PrivateAttr(default=None)
     __references__: DottedDict = PrivateAttr(default_factory=DottedDict)
+    __id__: Optional[str] = PrivateAttr(default_factory=uuid.uuid4)
 
     def __init__(self, **data):
         super().__init__(**data)


### PR DESCRIPTION
As discussed with @haeussma and Tim in our recent meeting, we need to add unique IDs by default to any object. So far, this was solved using the object name and an auto-incrementing integer. This works well for enclosed documents to reference parts of themselves, but redundancy will most likely occur in a database context.

Thus, this PR introduces a private attribute `__id__`, which contains a UUID. This UUID distinguishes an object beyond a document and as a primary key for databases. This solves the way data can be put into a database. 

Yet, there must be a way to recover these IDs from a database upon fetching a document. Specifically, when a document is re-built using the databases, the UUIDs should match. Hence, this PR will still be in draft state to solve this, as PyDantic so far does not have a way to assign private attributes upon initialization, only after that.

The following is a screenshot that demonstrates the changes and the added UUID:

<img width="1624" alt="image" src="https://github.com/JR-1991/software-driven-rdm/assets/30547301/3d37b146-84da-45e1-804a-65eaaf9eaa55">
