### PR TITLE
Raw XML type

### DIFF
--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -19,6 +19,7 @@ from enum import Enum
 from anytree import Node, LevelOrderIter
 from bigtree import print_tree, levelorder_iter, yield_tree
 from functools import lru_cache
+from lxml.etree import _Element
 from pydantic import ConfigDict, PrivateAttr, field_validator
 from typing import (
     Any,
@@ -265,7 +266,7 @@ class DataModel(pydantic_xml.BaseXmlModel):
         """Returns all possible paths of an instantiated data model. Can also be reduced to just leaves."""
 
         # Get JSON representation
-        model = Nob(self.to_dict(warn=False))
+        model = Nob(self.to_dict(warn=False, mode="python"))
 
         if leaves:
             return model.leaves
@@ -329,6 +330,7 @@ class DataModel(pydantic_xml.BaseXmlModel):
         mode="json",
         **kwargs,
     ):
+
         data = super().model_dump(
             exclude_none=exclude_none,
             by_alias=True,

--- a/sdRDM/generator/classrender.py
+++ b/sdRDM/generator/classrender.py
@@ -453,6 +453,8 @@ def assemble_signature(
     except StopIteration:
         if type in small_types:
             sub_object = small_types[type]
+        elif type in DataTypes.__members__:
+            return []
         else:
             raise ValueError(f"Sub object '{type}' has no attributes.")
 

--- a/sdRDM/generator/datatypes.py
+++ b/sdRDM/generator/datatypes.py
@@ -141,6 +141,7 @@ class DataTypes(Enum):
     )
     H5Dataset = ("H5Dataset", ["from h5py._hl.dataset import Dataset as H5Dataset"])
     h5dataset = ("H5Dataset", ["from h5py._hl.dataset import Dataset as H5Dataset"])
+    RawXML = ("_Element", ["from lxml.etree import _Element"])
 
     @classmethod
     def get_value_list(cls):

--- a/sdRDM/generator/templates/class_template.jinja2
+++ b/sdRDM/generator/templates/class_template.jinja2
@@ -19,3 +19,16 @@ class {{name}}({% if inherit is not none %}
     
     {% if repo is not none %}_repo: Optional[str] = PrivateAttr(default="{{repo}}"){% endif %}
     {% if commit is not none %}_commit: Optional[str] = PrivateAttr(default="{{commit}}"){% endif %}
+    _raw_xml_data: Dict = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _parse_raw_xml_data(self):
+        for attr, value in self:
+            if isinstance(value, (ListPlus, list)) and all(
+                isinstance(i, _Element) for i in value
+            ):
+                self._raw_xml_data[attr] = [elem2dict(i) for i in value]
+            elif isinstance(value, _Element):
+                self._raw_xml_data[attr] = elem2dict(value)
+
+        return self

--- a/sdRDM/generator/templates/import_template.jinja2
+++ b/sdRDM/generator/templates/import_template.jinja2
@@ -3,13 +3,17 @@ import sdRDM
 {{imports}}
 {% endfor %}
 
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict
 from uuid import uuid4
-from pydantic import PrivateAttr, field_validator
+from pydantic import PrivateAttr, field_validator, model_validator
 from pydantic_xml import attr, element, wrapped
+from lxml.etree import _Element
+
 from sdRDM.base.listplus import ListPlus
 from sdRDM.base.utils import forge_signature
 from sdRDM.base.datatypes import Unit
+from sdRDM.tools.utils import elem2dict
+
 {% for import in from_imports %}
 {{import}}
 {%- endfor %}

--- a/sdRDM/tools/utils.py
+++ b/sdRDM/tools/utils.py
@@ -50,3 +50,27 @@ def check_numeric(value):
         return value
     except ValueError:
         return f'"{value}"'
+
+
+def elem2dict(node):
+    """
+    Convert an lxml.etree node tree into a dict.
+
+    Args:
+        node (lxml.etree.Element): The lxml.etree node tree to be converted.
+
+    Returns:
+        dict: The converted dictionary representation of the node tree.
+    """
+    result = {}
+
+    for element in node.iterchildren():
+        key = element.tag.split("}")[1] if "}" in element.tag else element.tag
+        if element.text and element.text.strip():
+            value = element.text
+        else:
+            value = elem2dict(element)
+
+        result[key] = value
+
+    return result


### PR DESCRIPTION
* Adds new base type `RawXML` to include XML data varying in schma
* Directly parses raw XML data into the `_raw_xml_data` private attribute
* No need to parse XML manually, data will be at hand as a `dict` found by the attributes key