### PR TITLE
52 datamodelget does not get element if value is float0 or int0

### DIFF
--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -180,7 +180,7 @@ class DataModel(pydantic_xml.BaseXmlModel):
                 query,
             )
 
-            if reference:
+            if reference is not None:
                 references.append(reference)
 
         return references

--- a/tests/end2end/test_datamodel.py
+++ b/tests/end2end/test_datamodel.py
@@ -1,0 +1,26 @@
+from sdRDM import DataModel
+
+
+class TestGetMethod:
+
+    def test_get_method_by_meta_with_zeros(self, model_all):
+        """Tests whether the get_method_by_meta method returns the correct values"""
+
+        # Arrange
+        dataset = model_all.Root(
+            multiple_primitives=[0.0, 2.0],
+            nested_multiple_obj=[
+                model_all.Nested(float_value=0.0),
+                model_all.Nested(float_value=2.0),
+            ],
+        )
+
+        # Act
+        multiple_primitives = dataset.get("multiple_primitives")
+        nested_multiple_obj = dataset.get("nested_multiple_obj")
+        nested_multiple_obj_floats = dataset.get("nested_multiple_obj/float_value")
+
+        assert multiple_primitives == [[0.0, 2.0]]
+        assert all(isinstance(obj, model_all.Nested) for obj in nested_multiple_obj[0])
+        assert all(obj.float_value in [0.0, 2.0] for obj in nested_multiple_obj[0])
+        assert nested_multiple_obj_floats == [0.0, 2.0]


### PR DESCRIPTION
As mentioned in issue #52 this PR fixes zero-valued results not respected due to implicit query evaluation.

Fixes #52