### PR TITLE
Allow `id` field to be disabled

### DIFF
--- a/sdRDM/base/datamodel.py
+++ b/sdRDM/base/datamodel.py
@@ -46,7 +46,6 @@ from sdRDM.generator.codegen import generate_python_api
 from sdRDM.generator.utils import extract_modules
 from sdRDM.tools.utils import YAMLDumper
 from sdRDM.tools.gitutils import (
-    ObjectNode,
     build_library_from_git_specs,
     _import_library,
 )
@@ -623,15 +622,10 @@ class DataModel(pydantic_xml.BaseXmlModel):
 
     @classmethod
     def from_markdown(cls, path: str) -> ImportedModules:
-        """Fetches a Markdown specification from a git repository and builds the library accordingly.
-
-        This function will clone the repository into a temporary directory and
-        builds the correpsonding API and loads it into the memory. After that
-        the cloned repository is deleted and the root object(s) detected.
+        """Converts a markdown file into a in-memory Python API.
 
         Args:
-            url (str): Link to the git repository. Use the URL ending with ".git".
-            commit (Optional[str], optional): Hash of the commit to fetch from. Defaults to None.
+            path (str): Path to the markdown file.
         """
 
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -639,7 +633,10 @@ class DataModel(pydantic_xml.BaseXmlModel):
             lib_name = f"sdRDM-Library-{str(random.randint(0,30))}"
             api_loc = os.path.join(tmpdirname, lib_name)
             generate_python_api(
-                path=path, dirpath=tmpdirname, libname=lib_name, use_formatter=False
+                path=path,
+                dirpath=tmpdirname,
+                libname=lib_name,
+                use_formatter=False,
             )
 
             lib = _import_library(api_loc, lib_name)
@@ -665,6 +662,7 @@ class DataModel(pydantic_xml.BaseXmlModel):
             url (str): Link to the git repository. Use the URL ending with ".git".
             commit (Optional[str], optional): Hash of the commit to fetch from. Defaults to None.
             tag (Optional[str], optional): Tag of the release or branch to fetch from. Defaults to None.
+            only_classes (bool, optional): If True, only the classes will be returned. Defaults to False.
         """
 
         if not validators.url(url):

--- a/sdRDM/generator/classrender.py
+++ b/sdRDM/generator/classrender.py
@@ -18,6 +18,7 @@ def render_object(
     repo: Optional[str] = None,
     commit: Optional[str] = None,
     small_types: Dict = {},
+    add_id_field: bool = True,
 ) -> str:
     """Renders a class of type object coming from a parsed Markdown model"""
 
@@ -33,6 +34,7 @@ def render_object(
                     repo=repo,
                     commit=commit,
                     namespaces=namespaces,
+                    add_id_field=add_id_field,
                 )
                 for subtype in small_types.values()
                 if subtype["origin"] == object["name"]
@@ -49,6 +51,7 @@ def render_object(
         repo=repo,
         commit=commit,
         namespaces=namespaces,
+        add_id_field=add_id_field,
     )
 
     methods_part = render_add_methods(
@@ -88,6 +91,7 @@ def render_class(
     inherits: List[Dict],
     objects: List[Dict],
     namespaces: Dict,
+    add_id_field: bool,
     repo: Optional[str] = None,
     commit: Optional[str] = None,
 ) -> str:
@@ -105,7 +109,6 @@ def render_class(
     if filtered and len(filtered) == 1:
         inherit = filtered[0]["parent"]
 
-
     return template.render(
         name=name,
         inherit=inherit,
@@ -121,6 +124,7 @@ def render_class(
         repo=repo,
         commit=commit,
         namespaces=namespaces,
+        add_id_field=add_id_field,
     )
 
 
@@ -153,7 +157,9 @@ def render_attribute(
         attribute["default_factory"] = "ListPlus"
     elif not is_multiple and is_all_optional:
         attribute["default_factory"] = f"{attribute['type'][0]}"
-        del attribute["default"]
+
+        if "default" in attribute:
+            del attribute["default"]
 
     if has_reference:
         reference_types = get_reference_type(attribute["reference"], objects)

--- a/sdRDM/generator/codegen.py
+++ b/sdRDM/generator/codegen.py
@@ -79,6 +79,7 @@ def generate_api_from_parser(
         repo=url,
         commit=commit,
         namespaces=parser.namespaces,
+        add_id_field=parser.add_id_field,
     )
 
     # Write init files
@@ -112,6 +113,7 @@ def write_classes(
     namespaces: Dict,
     repo: Optional[str] = None,
     commit: Optional[str] = None,
+    add_id_field: bool = True,
 ) -> None:
     """Renders classes that were parsed from a markdown model and creates a library."""
 
@@ -132,6 +134,7 @@ def write_classes(
             commit=commit,
             small_types=small_types,
             namespaces=namespaces,
+            add_id_field=add_id_field,
         )
         path = os.path.join(libpath, "core", f"{object['name'].lower()}.py")
         save_rendered_to_file(rendered, path, use_formatter)

--- a/sdRDM/generator/templates/class_template.jinja2
+++ b/sdRDM/generator/templates/class_template.jinja2
@@ -9,17 +9,20 @@ class {{name}}({% if inherit is not none %}
                 {% endfor %}
                 },
                 {% endif %}
+                search_mode="unordered",
                 ):
 
                 
     {% if docstring is not none %}"""{{ docstring }}"""{% endif %}
     
+    {% if add_id_field %}
     id: Optional[str] = attr(
             name="id",
             description="Unique identifier of the given object.",
             default_factory=lambda: str(uuid4()),
             xml="@id"
     )
+    {% endif %}
     
     {% for attribute in attributes %}
     {{ attribute }}

--- a/sdRDM/markdown/objectutils.py
+++ b/sdRDM/markdown/objectutils.py
@@ -259,7 +259,9 @@ def process_type_option(
         if dtype.endswith("[]"):
             dtype = dtype.rstrip("[]")
             object_stack[-1]["attributes"][-1]["multiple"] = "True"
-            del object_stack[-1]["attributes"][-1]["default"]
+
+            if "default" in object_stack[-1]["attributes"][-1]:
+                del object_stack[-1]["attributes"][-1]["default"]
 
         if not dtype:
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,12 @@ def model_all_expected():
 
 
 @pytest.fixture
+def model_no_id():
+    """Loads the data model that has ID field disabled"""
+    return DataModel.from_markdown("tests/fixtures/static/model_minimal_no_id.md")
+
+
+@pytest.fixture
 def model_all_dataset(model_all):
     # Create a dataset with the given library
     nested = model_all.Nested(

--- a/tests/end2end/test_creation.py
+++ b/tests/end2end/test_creation.py
@@ -85,3 +85,17 @@ def test_ns_map(model_all):
     assert (
         model_all.Root.__xml_nsmap__ == expected
     ), "Namespace map does not match expected values"
+
+
+@pytest.mark.e2e
+def test_no_id_field(model_no_id):
+    """
+    Test that the 'id' field is not present in the model's fields.
+
+    Args:
+        model_no_id (object): The model object without the 'id' field.
+
+    Returns:
+        None
+    """
+    assert "id" not in model_no_id.Object.model_fields.keys()

--- a/tests/fixtures/static/model_minimal_no_id.md
+++ b/tests/fixtures/static/model_minimal_no_id.md
@@ -1,0 +1,17 @@
+---
+id-field: false
+---
+
+# Module
+
+Some description
+
+## Objects
+
+Other description
+
+### Object
+
+- attribute
+  - Type: int
+  - Description: Primitive attribute


### PR DESCRIPTION
This PR adds the option to disable the default addition of the `id` field. This is useful if an existing standard is adopted that does not rigorously use `id` field for each object. The `id` field can be disable by the addition of a YAML frontmatter:

**Example**

_Markdown_

```markdown
---
id-field: false
---

# My Model

## Objects

### Object

- attribute
  - Type: string
...
```

_Resulting code_


```python
@forge_signature
class Object(
    sdRDM.DataModel,
    search_mode="unordered",
):
    attribute: Optional[int] = element(
        default=None,
        tag="attribute",
        json_schema_extra=dict(),
    )
```
