### PR TITLE
Support `dimensionless` units of measurement

### DIFF
--- a/sdRDM/base/datatypes/unit.py
+++ b/sdRDM/base/datatypes/unit.py
@@ -4,7 +4,7 @@ from pydantic import model_validator
 import sdRDM
 
 from typing import List, Union
-from astropy.units import UnitBase, Unit as AstroUnit
+from astropy.units import UnitBase, Unit as AstroUnit, dimensionless_unscaled
 from pydantic import field_serializer, PrivateAttr
 
 
@@ -58,6 +58,8 @@ class Unit(
     def create_astropy_unit(self):
         if self._unit is None and self.name != "dimensionless":
             self._unit = AstroUnit(self.name)
+        elif self.name == "dimensionless":
+            self._unit = AstroUnit(dimensionless_unscaled)
 
         return self
 

--- a/sdRDM/base/datatypes/unit.py
+++ b/sdRDM/base/datatypes/unit.py
@@ -56,7 +56,7 @@ class Unit(
 
     @model_validator(mode="after")
     def create_astropy_unit(self):
-        if self._unit is None:
+        if self._unit is None and self.name != "dimensionless":
             self._unit = AstroUnit(self.name)
 
         return self
@@ -75,6 +75,13 @@ class Unit(
         Raises:
             AssertionError: If the unit is not a UnitBase or Unit.
         """
+
+        if unit_string.lower() == "dimensionless":
+            return cls(
+                name="dimensionless",
+                bases=[],
+            )
+
         unit = AstroUnit(unit_string)
 
         assert isinstance(

--- a/tests/unit/datatypes/test_unit.py
+++ b/tests/unit/datatypes/test_unit.py
@@ -1,0 +1,118 @@
+import json
+import re
+import pytest
+
+from sdRDM.base.datatypes.unit import BaseUnit, Unit
+from astropy.units import UnitBase, Unit as AstroUnit
+
+
+class TestUnit:
+    @pytest.mark.unit
+    def test_simple_unit_from_string(self):
+        # Arrange
+        unit_string = "m"
+
+        # Act
+        unit = Unit.from_string(unit_string)
+
+        # Assert
+        assert unit.name == "m"
+        assert unit.bases == [
+            BaseUnit(
+                kind="m",
+                exponent=1,
+                scale=1,
+            )
+        ]
+
+    @pytest.mark.unit
+    def test_composite_unit_from_string(self):
+        # Arrange
+        unit_string = "m/s"
+
+        # Act
+        unit = Unit.from_string(unit_string)
+
+        # Assert
+        assert unit.name == "m / s"
+        assert unit.bases == [
+            BaseUnit(
+                kind="m",
+                exponent=1,
+                scale=1,
+            ),
+            BaseUnit(
+                kind="s",
+                exponent=-1,
+                scale=1,
+            ),
+        ]
+
+    @pytest.mark.unit
+    def test_dimensionless_unit_from_string(self):
+        # Arrange
+        unit_string = "dimensionless"
+
+        # Act
+        unit = Unit.from_string(unit_string)
+
+        # Assert
+        assert unit.name == "dimensionless"
+        assert unit.bases == []
+
+    @pytest.mark.unit
+    def test_json_serialization(self):
+        # Arrange
+        unit_string = "m/s"
+
+        # Act
+        unit = Unit.from_string(unit_string)
+        unit_json = unit.json(exclude={"id"})
+
+        # Assert
+        expected_json = {
+            "name": "m / s",
+            "bases": [
+                {
+                    "kind": "m",
+                    "exponent": 1,
+                    "scale": 1,
+                },
+                {
+                    "kind": "s",
+                    "exponent": -1,
+                    "scale": 1,
+                },
+            ],
+        }
+
+        assert json.loads(unit_json) == expected_json
+
+    @pytest.mark.unit
+    def test_to_unit_string(self):
+        # Arrange
+        unit_string = "m/s"
+        unit = Unit.from_string(unit_string)
+
+        # Act
+        string = unit.to_unit_string()
+
+        # Assert
+        assert string == "m / s"
+
+    @pytest.mark.unit
+    def test_xml_serialization(self):
+        # Arrange
+        unit_string = "m/s"
+
+        # Act
+        unit = Unit.from_string(unit_string)
+        unit_xml = unit.xml()
+
+        # Assert
+        expected_xml = '<?xml version="1.0" encoding="UTF-8"?><Unit  name="m / s">  <listOfUnits>    <unit scale="1.0" kind="m" exponent="1.0"/>    <unit scale="1.0" kind="s" exponent="-1.0"/>  </listOfUnits></Unit>'
+
+        unit_xml = unit_xml.replace("\n", "").replace("'", '"')
+        unit_xml = re.sub(r'id="[\w-]+"', "", unit_xml)
+
+        assert unit_xml == expected_xml


### PR DESCRIPTION
As higlighted in #56 the current implementation does not allow to add dimensionless units. This PR fixes it by providing a way to add this type of unit. The resulting `Unit` object will only contain the name `dimensionless` with an empty list of `bases`. In addition, the corresponding `Unit(dimensionless_unscaled)` will be added to the `_unit` attribute.

**Example**

```python
unit = Unit.from_string("dimensionless")
print(unit.json())
```

_Output_
```json
{
  "my_unit": {
    "id": "6a632e6b-a6bf-4a63-952f-ce037206c6b8",
    "name": "dimensionless",
    "bases": []
  }
}
```

Closes #56 