### PR TITLE
Enable XML leaf elements

### DIFF
--- a/sdRDM/generator/classrender.py
+++ b/sdRDM/generator/classrender.py
@@ -58,6 +58,7 @@ def render_object(
         object=object,
         objects=all_objects,
         small_types=small_types,
+        add_id_field=add_id_field,
     )
 
     validator_part = render_reference_validator(
@@ -333,7 +334,12 @@ def is_reference(key: str, option: str) -> bool:
     return False
 
 
-def render_add_methods(object: Dict, objects: List[Dict], small_types: Dict) -> str:
+def render_add_methods(
+    object: Dict,
+    objects: List[Dict],
+    small_types: Dict,
+    add_id_field: bool,
+) -> str:
     """Renders add methods fro each non-native type of an attribute"""
 
     add_methods = []
@@ -349,12 +355,13 @@ def render_add_methods(object: Dict, objects: List[Dict], small_types: Dict) -> 
         for type in complex_types:
             add_methods.append(
                 render_single_add_method(
-                    attribute,
-                    type,
-                    objects,
-                    is_single_type,
-                    object["name"],
-                    small_types,
+                    attribute=attribute,
+                    type=type,
+                    objects=objects,
+                    is_single_type=is_single_type,
+                    obj_name=object["name"],
+                    small_types=small_types,
+                    add_id_field=add_id_field,
                 )
             )
 
@@ -427,6 +434,7 @@ def render_single_add_method(
     is_single_type: bool,
     obj_name: str,
     small_types: Dict,
+    add_id_field: bool,
 ) -> str:
     """Renders an add method for an attribute that occurs multiple times"""
 
@@ -452,6 +460,7 @@ def render_single_add_method(
         cls=type,
         signature=assemble_signature(type, objects, obj_name, small_types),
         summary=f"This method adds an object of type '{type}' to attribute {attribute['name']}",
+        add_id_field=add_id_field,
     )
 
 

--- a/sdRDM/generator/classrender.py
+++ b/sdRDM/generator/classrender.py
@@ -136,10 +136,17 @@ def render_attribute(
     """Renders an attributeibute to code using a Jinja2 template"""
 
     attribute = deepcopy(attribute)
-    template = Template(
+    attr_template = Template(
         pkg_resources.read_text(
             jinja_templates,
             "attribute_template.jinja2",
+        )
+    )
+
+    leaf_template = Template(
+        pkg_resources.read_text(
+            jinja_templates,
+            "attribute_leaf_template.jinja2",
         )
     )
 
@@ -173,16 +180,29 @@ def render_attribute(
         xml_alias = None
         wrapped = False
 
-    return template.render(
-        name=attribute.pop("name"),
-        required=attribute.pop("required"),
-        dtype=combine_types(attribute.pop("type"), is_multiple, is_required),
-        metadata=stringize_option_values(attribute),
-        field_type=_get_field_type(attribute),
-        wrapped=wrapped,
-        tag=tag,
-        xml_alias=xml_alias,
-    )
+    if xml_alias == obj_name or tag == obj_name:
+        return leaf_template.render(
+            name=attribute.pop("name"),
+            required=attribute.pop("required"),
+            dtype=combine_types(attribute.pop("type"), is_multiple, is_required),
+            metadata=stringize_option_values(attribute),
+            field_type=_get_field_type(attribute),
+            wrapped=wrapped,
+            tag=tag,
+            xml_alias=xml_alias,
+        )
+
+    else:
+        return attr_template.render(
+            name=attribute.pop("name"),
+            required=attribute.pop("required"),
+            dtype=combine_types(attribute.pop("type"), is_multiple, is_required),
+            metadata=stringize_option_values(attribute),
+            field_type=_get_field_type(attribute),
+            wrapped=wrapped,
+            tag=tag,
+            xml_alias=xml_alias,
+        )
 
 
 def _get_field_type(attribute: Dict) -> str:

--- a/sdRDM/generator/templates/add_method_template.jinja2
+++ b/sdRDM/generator/templates/add_method_template.jinja2
@@ -3,13 +3,13 @@
         {%- for attr in signature %}
         {{attr.name}}: {{attr.type}} {% if 'default' in attr%}= {{attr.default}} {% elif attr.multiple is true %}= ListPlus(){% endif %},
         {%- endfor %}
-        id: Optional[str] = None,
+        {% if add_id_field %}id: Optional[str] = None,{% endif %}
     ) -> {{ cls }}:
         """
         {{summary}}
 
         Args:
-            id (str): Unique identifier of the '{{ cls }}' object. Defaults to 'None'.
+            {% if add_id_field %}id (str): Unique identifier of the '{{ cls }}' object. Defaults to 'None'.{% endif %}
             {%- for attr in signature %}
             {{attr.name}} ({{ attr.dtype }}): {{ attr.description }}.{% if 'default' in attr %} Defaults to {{attr.default}}{% endif %}
             {%- endfor %}

--- a/sdRDM/generator/templates/attribute_leaf_template.jinja2
+++ b/sdRDM/generator/templates/attribute_leaf_template.jinja2
@@ -1,0 +1,14 @@
+{{name}}: {{dtype}} = Field(
+    {% if required is false and 'default' not in metadata.keys() and 'default_factory' not in metadata.keys() %}default=None,{% endif %}
+    {% if "description" in metadata %}description={{metadata["description"]}},{% endif %}
+    {% if "default" in metadata %}default={{metadata["default"]}},{% endif %}
+    {% if "default_factory" in metadata %}default_factory={{metadata["default_factory"]}},{% endif %}
+    json_schema_extra=dict(
+        {% for key, value in metadata.items() %}
+        {% if not key in ["default", "description", "default_factory"]%}
+        {{key}}={{value}},
+        {% endif %}
+        {% endfor %}
+    ),
+    )
+

--- a/sdRDM/generator/templates/import_template.jinja2
+++ b/sdRDM/generator/templates/import_template.jinja2
@@ -5,7 +5,7 @@ import sdRDM
 
 from typing import Optional, Union, List, Dict
 from uuid import uuid4
-from pydantic import PrivateAttr, field_validator, model_validator
+from pydantic import PrivateAttr, Field, field_validator, model_validator
 from pydantic_xml import attr, element, wrapped
 from lxml.etree import _Element
 

--- a/sdRDM/markdown/objectutils.py
+++ b/sdRDM/markdown/objectutils.py
@@ -209,7 +209,9 @@ def process_option(
     if option.lower().strip() == "type":
         value = process_type_option(value, object_stack, external_types)
     elif option.lower().strip() == "multiple" and attribute_has_default(object_stack):
-        del object_stack[-1]["attributes"][-1]["default"]
+
+        if "default" in object_stack[-1]["attributes"][-1]:
+            del object_stack[-1]["attributes"][-1]["default"]
         object_stack[-1]["attributes"][-1]["default_factory"] = "ListPlus()"
 
     object_stack[-1]["attributes"][-1][option.strip().lower()] = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,12 @@ def model_all_dataset(model_all):
         int_value=1,
     )
 
+    leaf_element = model_all.LeafElement(
+        id="id",
+        leaf_value="I am a leaf",
+        some_attribute="I am an attribute",
+    )
+
     dataset = model_all.Root(
         id="id",
         str_value="string",
@@ -67,6 +73,7 @@ def model_all_dataset(model_all):
         nested_single_obj=nested,
         nested_multiple_obj=[nested],
         referenced_value=nested,
+        leaf_element=leaf_element,
     )
 
     return dataset

--- a/tests/end2end/test_schemes.py
+++ b/tests/end2end/test_schemes.py
@@ -17,6 +17,7 @@ def test_scheme(model_all):
     NoneType = type(None)
     SomeEnum = model_all.enums.SomeEnum
     Nested = model_all.Nested
+    LeafElement = model_all.LeafElement
 
     expected_scheme = [
         ("id", Optional[str]),
@@ -35,6 +36,7 @@ def test_scheme(model_all):
         ("enum_value", Union[SomeEnum, NoneType]),
         ("nested_single_obj", Union[Nested, NoneType]),
         ("nested_multiple_obj", List[Nested]),
+        ("leaf_element", Union[LeafElement, NoneType]),
     ]
 
     given_scheme = [

--- a/tests/fixtures/static/model_all.md
+++ b/tests/fixtures/static/model_all.md
@@ -45,6 +45,9 @@ This model tests all methods and types that are present within the sdRDM library
 - nested_multiple_obj
   - Type: Nested[]
   - XML: nested_multiple_obj/nested
+- leaf_element
+  - Type: LeafElement
+  - XML: leaf_element
 
 ### Nested
 
@@ -54,6 +57,15 @@ This model tests all methods and types that are present within the sdRDM library
   - Type: float
 - int_value
   - Type: integer
+
+### LeafElement
+
+- leaf_value
+  - Type: string
+  - XML: LeafElement
+- some_attribute
+  - Type: string
+  - XML: @some_attribute
 
 ## Enumerations
 

--- a/tests/fixtures/static/model_all_expected.json
+++ b/tests/fixtures/static/model_all_expected.json
@@ -30,5 +30,10 @@
             "float_value": 1.5,
             "int_value": 1
         }
-    ]
+    ],
+    "leaf_element": {
+        "id": "id",
+        "leaf_value": "I am a leaf",
+        "some_attribute": "I am an attribute"
+    }
 }

--- a/tests/fixtures/static/model_all_expected.xml
+++ b/tests/fixtures/static/model_all_expected.xml
@@ -27,4 +27,5 @@
       <int_value>1</int_value>
     </nested>
   </nested_multiple_obj>
+  <leaf_element id="id" some_attribute="I am an attribute">I am a leaf</leaf_element>
 </Root>

--- a/tests/fixtures/static/model_all_expected.yaml
+++ b/tests/fixtures/static/model_all_expected.yaml
@@ -25,3 +25,7 @@ nested_multiple_obj:
     str_value: string
     float_value: 1.5
     int_value: 1
+leaf_element:
+  id: id
+  leaf_value: I am a leaf
+  some_attribute: I am an attribute


### PR DESCRIPTION
This PR introduces the ability to specify leaf elements for XML data models. A leaf element is a terminal string that is encapsulated by the given element. This means, that there are no other elements in the element other than XML attributes. For instance, the following example demonstrates a use case:

_XML output_

```xml
<leafElement someAttr="XYZ">
    This is a simple leaf element
</leafElement>
```

Within the markdown specs, a leaf element can be configured by setting `XML: <Name of the class>`, which will signal the sdRDM compiler that the given attribute is to be used as a leaf element. Please note, the XML alias has to have the same name as teh class. Otherwise, a new element will be created.

_Markdown_

```markdown
### LeafElement

- value
   - Type: string
   - XML: LeafElement
- someAttr
   - Type: string
   - XML: @someAttr
```

_(Generated code will be the same as usual)_

**TLDR**

* Allow leaf XML elements
* Specified by `XML: <Class name>` --> Turns attribute to function as desired
* Added tests for leaf element 

**Closes**

closes #20 