### PR TITLE
Generate `__init__` only if it does not exist

### DIFF
--- a/sdRDM/generator/codegen.py
+++ b/sdRDM/generator/codegen.py
@@ -90,12 +90,12 @@ def generate_api_from_parser(
         use_formatter,
     )
 
-    lib_init = render_library_init_file(parser.objects, parser.enums, url, commit)
-    save_rendered_to_file(
-        lib_init,
-        os.path.join(libpath, "__init__.py"),
-        use_formatter,
-    )
+    if not os.path.exists(os.path.join(libpath, "__init__.py")):
+        save_rendered_to_file(
+            "",
+            os.path.join(libpath, "__init__.py"),
+            use_formatter,
+        )
 
     # Write schema to library
     generate_mermaid_schema(os.path.join(libpath, "schemes"), libname, parser)


### PR DESCRIPTION
**Overview**

As highlighted in #67 the `__init__.py` generate at the top-level of a generated library, does not respect additions. This PR fixes the issue, by only creating the `__init__.py` if none exists. Since this file typically contains nothing upon generation, this PR only uses an `if`-condition to make it work. Keep it simple :)

**TLDR**

* Only generate `library/__init__.py` if no-existent

Closes #67 
